### PR TITLE
Please use normal slashes as path seperator

### DIFF
--- a/src/main/java/com/setycz/chickens/ChickensMod.java
+++ b/src/main/java/com/setycz/chickens/ChickensMod.java
@@ -225,7 +225,7 @@ public class ChickensMod {
 
     private void dumpChickens(Collection<ChickensRegistryItem> items) {
         try {
-            FileWriter file = new FileWriter("logs\\chickens.gml");
+            FileWriter file = new FileWriter("logs/chickens.gml");
             file.write("graph [\n");
             file.write("\tdirected 1\n");
             for (ChickensRegistryItem item : items) {


### PR DESCRIPTION
Please don't use backslashes. It's not a path separator anywhere but on windows, which makes the file appear like this "logs\chickens.gml" in the server root.
