### PR TITLE
Add configurable crossbreeding stat inheritance

### DIFF
--- a/src/main/java/com/setycz/chickens/config/ConfigHandler.java
+++ b/src/main/java/com/setycz/chickens/config/ConfigHandler.java
@@ -30,6 +30,8 @@ public class ConfigHandler {
     public static int maxBroodSize = 5;
     public static float netherSpawnChanceMultiplier = 1.0f;
     public static boolean alwaysShowStats = false;
+    public static boolean crossbreedInheritStats = false;
+    public static float crossbreedInheritStatsRatio = 1.0f;
 
 	
     public static void LoadConfigs(List<ChickensRegistryItem> allchickens) {
@@ -53,6 +55,8 @@ public class ConfigHandler {
 	        maxBroodSize = mainConfig.getInt("maxBroodSize", "general", 5, 2, Integer.MAX_VALUE, "Maximal brood size, must be greater than the minimal size");
 	        netherSpawnChanceMultiplier = mainConfig.getFloat("netherSpawnChanceMultiplier", "general", 1.0f, 0.f, Float.MAX_VALUE, "Nether chicken spawn chance multiplier, e.g. 0=no initial spawn, 2=two times more spawn rate");
 	        alwaysShowStats = mainConfig.getBoolean("alwaysShowStats", "general", false, "Stats will be always shown in WAILA without the need to analyze chickens first when enabled.");
+	        crossbreedInheritStats = mainConfig.getBoolean("crossbreedInheritStats", "general", false, "Crossbred offspring will inherit the average stats of the parents.");
+	        crossbreedInheritStatsRatio = mainConfig.getFloat("crossbreedInheritStatsRatio", "general", 1.0f, 0.1f, 1.0f, "The ratio at which offspring inherit parent stats. 1.0 = average stats of parents.");
 
 			if (mainConfig.hasChanged()) {
 	        mainConfig.save();

--- a/src/main/java/com/setycz/chickens/entity/EntityChickensChicken.java
+++ b/src/main/java/com/setycz/chickens/entity/EntityChickensChicken.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import javax.annotation.Nullable;
 
 import com.setycz.chickens.block.TileEntityHenhouse;
+import com.setycz.chickens.config.ConfigHandler;
 import com.setycz.chickens.handler.SpawnType;
 import com.setycz.chickens.registry.ChickensRegistry;
 import com.setycz.chickens.registry.ChickensRegistryItem;
@@ -136,6 +137,8 @@ public class EntityChickensChicken extends EntityChicken {
             inheritStats(newChicken, this);
         } else if (mateChickenDescription.getRegistryName() == childToBeBorn.getRegistryName()) {
             inheritStats(newChicken, mateChicken);
+        } else if (ConfigHandler.crossbreedInheritStats) {
+            inheritStatsCrossbreeding(newChicken, this, mateChicken);
         }
 
         return newChicken;
@@ -145,6 +148,13 @@ public class EntityChickensChicken extends EntityChicken {
         newChicken.setGrowth(parent.getGrowth());
         newChicken.setGain(parent.getGain());
         newChicken.setStrength(parent.getStrength());
+    }
+
+    private void inheritStatsCrossbreeding(EntityChickensChicken newChicken, EntityChickensChicken parent1, EntityChickensChicken parent2) {
+        float ratio = ConfigHandler.crossbreedInheritStatsRatio;
+        newChicken.setGrowth(Math.max((int) (((parent1.getGrowth() + parent2.getGrowth()) / 2.0f) * ratio), 1));
+        newChicken.setGain(Math.max((int) (((parent1.getGain() + parent2.getGain()) / 2.0f) * ratio), 1));
+        newChicken.setStrength(Math.max((int) (((parent1.getStrength() + parent2.getStrength()) / 2.0f) * ratio), 1));
     }
 
     private static void increaseStats(EntityChickensChicken newChicken, EntityChickensChicken parent1, EntityChickensChicken parent2, Random rand) {


### PR DESCRIPTION
Hello,

Here is a small change that adds configurable stat inheritance for cross breeding. By default it is disabled. If enabled, the crossbred offspring will inherit the average stats of the parents. This is with ratio set to 1.0. With ratio set to 0.5 the offspring gets 50% of the parent average for each stat.