### PR TITLE
Backport TheOneProbe support to 1.10.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ repositories {
     maven { url "http://mobiusstrip.eu/maven" }
     maven { url = "http://chickenbones.net/maven/" }
     maven { url "http://dvs1.progwml6.com/files/maven" }
+    maven { // TOP
+        name 'tterrag maven'
+        url "http://maven.tterrag.com/"
+    }
 }
 
 dependencies {
@@ -75,6 +79,7 @@ dependencies {
 
     deobfCompile "mezz.jei:jei_1.10.2:3.13.6.387"
     compile "mcp.mobius.waila:Waila:1.7.0-B3_1.9.4"
+    deobfCompile "mcjty.theoneprobe:TheOneProbe:${top_version}"
 }
 
 processResources

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ forgeversion_suffix=
 
 curse_project_id=241941
 
-modversion=4.3.2
+modversion=4.3.3
 releaseType=release
 
+top_version=1.1x-1.4.19-61

--- a/src/main/java/com/setycz/chickens/ChickensMod.java
+++ b/src/main/java/com/setycz/chickens/ChickensMod.java
@@ -24,6 +24,7 @@ import net.minecraft.world.biome.Biome;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fluids.FluidRegistry;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.SidedProxy;
@@ -265,6 +266,10 @@ public class ChickensMod {
 
         // waila integration
         FMLInterModComms.sendMessage("Waila", "register", "com.setycz.chickens.waila.ChickensEntityProvider.load");
+
+        if (Loader.isModLoaded("theoneprobe")) {
+            FMLInterModComms.sendFunctionMessage("theoneprobe", "GetTheOneProbe", "com.setycz.chickens.top.TheOneProbePlugin$GetTheOneProbe");
+        }
     }
 
     private boolean requiresVisitingNether(ChickensRegistryItem chicken) {

--- a/src/main/java/com/setycz/chickens/top/TheOneProbePlugin.java
+++ b/src/main/java/com/setycz/chickens/top/TheOneProbePlugin.java
@@ -1,0 +1,72 @@
+package com.setycz.chickens.top;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.Function;
+import com.setycz.chickens.ChickensMod;
+import com.setycz.chickens.chicken.EntityChickensChicken;
+
+import mcjty.theoneprobe.api.IProbeHitEntityData;
+import mcjty.theoneprobe.api.IProbeInfo;
+import mcjty.theoneprobe.api.IProbeInfoEntityProvider;
+import mcjty.theoneprobe.api.ITheOneProbe;
+import mcjty.theoneprobe.api.ProbeMode;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+public class TheOneProbePlugin implements IProbeInfoEntityProvider  {
+
+	@Override
+	public String getID() {
+
+		return ChickensMod.MODID +":chickenstop";
+	}
+
+	@Override
+	public void addProbeEntityInfo(ProbeMode mode, IProbeInfo probeInfo, EntityPlayer player, World world, Entity entity, IProbeHitEntityData data) 
+	{
+		
+		if(entity instanceof EntityChickensChicken) {
+			EntityChickensChicken chicken = (EntityChickensChicken) entity;
+			
+			probeInfo.text(translate("entity.ChickensChicken.top.tier") +" "+ chicken.getTier());
+			
+	        if (chicken.getStatsAnalyzed() || ChickensMod.instance.getAlwaysShowStats()) {
+	        	probeInfo.text(translate("entity.ChickensChicken.top.growth") +" "+ chicken.getGrowth());
+	        	probeInfo.text(translate("entity.ChickensChicken.top.gain") +" "+ chicken.getGain());
+	        	probeInfo.text(translate("entity.ChickensChicken.top.strength") +" "+ chicken.getStrength());
+			}
+	        
+	        if (!chicken.isChild()) {
+	            int layProgress = chicken.getLayProgress();
+	            if (layProgress <= 0) {
+	            	probeInfo.text(translate("entity.ChickensChicken.top.nextEggSoon"));
+	            } else {
+	            	probeInfo.text(translate("entity.ChickensChicken.top.layProgress") +" "+layProgress + translate("entity.ChickensChicken.top.layProgressEnd"));
+	            }
+	        }
+		}
+		
+	}
+	
+	
+	public static String translate(String text) {
+		return IProbeInfo.STARTLOC + text + IProbeInfo.ENDLOC;
+	}
+		
+	public static class GetTheOneProbe implements Function<ITheOneProbe, Void> 
+	{
+
+		public static ITheOneProbe theOneProbe;
+
+		@Nullable
+		@Override
+		public Void apply (ITheOneProbe input) {
+
+			theOneProbe = input;
+			theOneProbe.registerEntityProvider(new TheOneProbePlugin());
+			return null;
+		}
+	}
+}

--- a/src/main/resources/assets/chickens/lang/en_US.lang
+++ b/src/main/resources/assets/chickens/lang/en_US.lang
@@ -74,6 +74,15 @@ entity.ChickensChicken.nextEggSoon=Next egg in <1min.
 entity.ChickensChicken.growth=Growth: %1$s
 entity.ChickensChicken.gain=Gain: %1$s
 entity.ChickensChicken.strength=Strength: %1$s
+
+entity.ChickensChicken.top.tier=Tier: 
+entity.ChickensChicken.top.layProgress=Next egg in
+entity.ChickensChicken.top.layProgressEnd=min.
+entity.ChickensChicken.top.nextEggSoon=Next egg in <1min.
+entity.ChickensChicken.top.growth=Growth: 
+entity.ChickensChicken.top.gain=Gain: 
+entity.ChickensChicken.top.strength=Strength: 
+
 gui.laying=Laying Egg
 gui.laying.time=%1$s-%2$smin.
 gui.breeding=Chicken Breeding


### PR DESCRIPTION
I wanted to use the one probe in my Sky Factory instead of hwyla, but I missed my chickens info. Just cherry picked the commit from the 1.12 branch and resolved conflicts.